### PR TITLE
Rename remaining org-force-cycle-archived → org-cycle-force-archived

### DIFF
--- a/lisp/org-cycle.el
+++ b/lisp/org-cycle.el
@@ -722,7 +722,7 @@ STATE should be one of the symbols listed in the docstring of
 	(when (looking-at-p (concat ".*:" org-archive-tag ":"))
 	  (message "%s" (substitute-command-keys
 			 "Subtree is archived and stays closed.  Use \
-`\\[org-force-cycle-archived]' to cycle it anyway.")))))))
+`\\[org-cycle-force-archived]' to cycle it anyway.")))))))
 
 (provide 'org-cycle)
 

--- a/lisp/org-keys.el
+++ b/lisp/org-keys.el
@@ -93,7 +93,7 @@
 (declare-function org-fill-paragraph "org" (&optional justify region))
 (declare-function org-find-file-at-mouse "org" (ev))
 (declare-function org-footnote-action "org" (&optional special))
-(declare-function org-force-cycle-archived "org" ())
+(declare-function org-cycle-force-archived "org" ())
 (declare-function org-force-self-insert "org" (n))
 (declare-function org-forward-element "org" ())
 (declare-function org-forward-heading-same-level "org" (arg &optional invisible-ok))
@@ -445,7 +445,7 @@ COMMANDS is a list of alternating OLDDEF NEWDEF command names."
 ;;;; TAB key with modifiers
 (org-defkey org-mode-map (kbd "C-i") #'org-cycle)
 (org-defkey org-mode-map (kbd "<tab>") #'org-cycle)
-(org-defkey org-mode-map (kbd "C-c C-<tab>") #'org-force-cycle-archived)
+(org-defkey org-mode-map (kbd "C-c C-<tab>") #'org-cycle-force-archived)
 ;; Override text-mode binding to expose `complete-symbol' for
 ;; pcomplete functionality.
 (org-defkey org-mode-map (kbd "M-<tab>") nil)

--- a/lisp/org.el
+++ b/lisp/org.el
@@ -103,6 +103,7 @@
 (defalias 'org-global-cycle #'org-cycle-global)
 (defalias 'org-overview #'org-cycle-overview)
 (defalias 'org-content #'org-cycle-content)
+(defalias 'org-force-cycle-archived #'org-cycle-force-archived)
 
 ;; `org-outline-regexp' ought to be a defconst but is let-bound in
 ;; some places -- e.g. see the macro `org-with-limited-levels'.


### PR DESCRIPTION
Perhaps a tinychange but I’ve also signed FSF papers for eventual upstreaming