### PR TITLE
Fix bug in org-get-heading

### DIFF
--- a/lisp/org.el
+++ b/lisp/org.el
@@ -6218,9 +6218,9 @@ Return nil before first heading."
 	(looking-at org-complex-heading-regexp)
         ;; When using `org-fold-core--optimise-for-huge-buffers',
         ;; returned text will be invisible.  Clear it up.
-        (org-fold-core-remove-optimisation (match-beginning 0) (match-end 0))
-        (when font-lock-mode (org-fold-core-fontify-region (match-beginning 0) (match-end 0) nil 'force))
-        (looking-at org-complex-heading-regexp)
+        (save-match-data
+          (org-fold-core-remove-optimisation (match-beginning 0) (match-end 0))
+          (when font-lock-mode (org-fold-core-fontify-region (match-beginning 0) (match-end 0) nil 'force)))
         (let ((todo (and (not no-todo) (match-string 2)))
 	      (priority (and (not no-priority) (match-string 3)))
 	      (headline (pcase (match-string 4)


### PR DESCRIPTION
Fixes #26, where fontification could make the matching and extraction of heading
components fail.