### PR TITLE
Adapt org-string-width to use correct face in width calculation

### DIFF
--- a/lisp/org-macs.el
+++ b/lisp/org-macs.el
@@ -944,7 +944,7 @@ delimiting S."
 Outline, block, and drawer folds will be ignored."
   ;; Wrap/line prefix will make `window-text-pizel-size' return too
   ;; large value including the prefix.
-  (remove-text-properties 0 (length string) '(wrap-prefix t line-prefix t) string)
+  (remove-text-properties 0 (length string) '(wrap-prefix t line-prefix t face t) string)
   (let (;; We need to remove the folds to make sure that folded table alignment is not messed up.
         (current-invisibility-spec (or (and (not (listp buffer-invisibility-spec))
                                             buffer-invisibility-spec)


### PR DESCRIPTION
I stumbled upon another problem with the table alignment and `org-string-width`.

I use a narrower font for `org-table` to be able to fit wide tables a bit easier in a window. The calculation in `org-string-width` didn’t take this into account however, which lead to wrong alignment again (for example with the width of short strings in the table like "p" being reported as zero as the displayed "p" with the narrow font would be narrower than the "a" in the default font it was compared to.

I don’t think this is a very elegant solution, but it solves this case for tables at least. It does make org-string-width less elegant.

Before:
![Skärmbild från 2021-04-30 15-50-37](https://user-images.githubusercontent.com/846411/116705126-81bcf900-a9cc-11eb-81d5-abd0497bccc5.png)

After:
![Skärmbild från 2021-04-30 15-51-03](https://user-images.githubusercontent.com/846411/116705182-8bdef780-a9cc-11eb-96e1-df8f71de37d0.png)

