### PR TITLE
Update doom installation instruction

### DIFF
--- a/README
+++ b/README
@@ -76,12 +76,12 @@ Adopted from [[https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/
   :recipe (:host github
            :repo "yantar92/org"
            :branch "feature/org-fold-universal-core"
-           :files ("*.el" "lisp/*.el" "contrib/lisp/*.el")
+           :files ("*.el" "lisp/*.el")
            :pre-build (with-temp-file (expand-file-name "org-version.el" (straight--repos-dir "org"))
                         (insert "(fset 'org-release (lambda () \"9.5\"))\n"
                                 "(fset 'org-git-version #'ignore)\n"
-                                "(provide 'org-version)\n")))
-  :shadow 'org)
+                                "(provide 'org-version)\n"))
+           :includes (org)))
 #+end_src
 
 ** Using [[https://github.com/raxod502/straight.el/][Straight.el]]


### PR DESCRIPTION
As for the recent commit, [29059bacbe](https://github.com/hlissner/doom-emacs/commit/29059bacbe0432b4e41a7fd4ed9e3172df1d7863#diff-9be23fd924f084574d83d4d968639de518ab8ae4ac17d3d0c8b0459292a59751), `:shadow` became obsolete. Instead, using `:includes` is the canonical way to do it. Plus, contribution folder, `contrib/*.el`, factored out with org version of 9.5.