### PR TITLE
`copy-list` is an obsolete name, need to prepend `cl`

### DIFF
--- a/lisp/org.el
+++ b/lisp/org.el
@@ -11491,9 +11491,9 @@ The tags are fontified when FONTIFY is non-nil."
                      (org-element--cache-find (point)))))
     (if (and (eq 'headline (org-element-type cached))
              (eq (point) (org-element-property :post-affiliated cached)))
-        ;; If we do not wrap result into `copy-list', reference would
+        ;; If we do not wrap result into `cl-copy-list', reference would
         ;; be returned and cache element might be modified directly.
-        (copy-list (org-element-property :tags cached))
+        (cl-copy-list (org-element-property :tags cached))
       (and (if fontified
                (org-looking-at-fontified org-tag-line-re)
              (looking-at org-tag-line-re))


### PR DESCRIPTION
I confronted an error saying void function `copy-list`. Seems like it should be `cl-copy-list` as a dependency to `cl` should be written as `cl-lib`.