### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ ChangeLog
 /org-pkg.el
 /org-autoloads.el
 /lisp/org-autoloads.el
+/lisp/org-loaddefs.el
+/lisp/org-version.el
+
 
 # texi2pdf --tidy
 


### PR DESCRIPTION
When it comes to updating and rebuilding **org** package with **feature/org-fold-universal-core** branch, **straight.el** gives the following alert:

![2021-11-23_08-12](https://user-images.githubusercontent.com/3141865/143030808-79b96585-ebf7-47ef-94fb-a24ea70a5b3f.png)
